### PR TITLE
fix wrong inferred type parcelable

### DIFF
--- a/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/models/CardDetails.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/models/CardDetails.kt
@@ -12,10 +12,10 @@ data class CardDetails(
         val expiryDate: String = "") : Parcelable {
 
   constructor(parcel: Parcel) : this(
-          parcel.readString(),
-          parcel.readString(),
-          parcel.readString(),
-          parcel.readString()) {
+          parcel.readString() ?: "",
+          parcel.readString() ?: "",
+          parcel.readString() ?: "",
+          parcel.readString() ?: "") {
   }
 
   fun toMap(): Map<String, String> {


### PR DESCRIPTION
Fixed wrong inferred type when reading parcelable to create a CardDetail object by making a null coallescing, refer to this issue #26 