### PR TITLE
Docs: add missing semicolons in example snippet.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ Just import the package and call `scanCard`:
 
 ```dart
 import 'package:card_scanner/card_scanner.dart';
-var cardDetails = await CardScanner.scanCard()
+var cardDetails = await CardScanner.scanCard();
 
-print(cardDetails)
+print(cardDetails);
 ```
 
 Example Output:


### PR DESCRIPTION
Minor, but first snippet is missing semicolons and throws errors.