### PR TITLE
Fix crash, add configurable prompt, Android flashlight & upgrade dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -19,7 +19,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 
@@ -49,14 +49,14 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'com.google.android.gms:play-services-mlkit-text-recognition:18.0.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'com.google.android.gms:play-services-mlkit-text-recognition:19.0.1'
 
 // CameraX core library using camera2 implementation
-    implementation "androidx.camera:camera-camera2:1.1.0-alpha01"
+    implementation "androidx.camera:camera-camera2:1.3.4"
 // CameraX Lifecycle Library
-    implementation "androidx.camera:camera-lifecycle:1.1.0-alpha01"
+    implementation "androidx.camera:camera-lifecycle:1.3.4"
 // CameraX View class
-    implementation "androidx.camera:camera-view:1.0.0-alpha21"
+    implementation "androidx.camera:camera-view:1.3.4"
 }

--- a/android/src/main/java/com/nateshmbhat/card_scanner/CardScannerCameraActivity.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/CardScannerCameraActivity.kt
@@ -170,6 +170,7 @@ class CardScannerCameraActivity : AppCompatActivity() {
     textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
     debugLog("card scanner options : $cardScannerOptions", cardScannerOptions)
+    cardScanner?.cancelTimer()
     cardScanner = CardScanner(cardScannerOptions, { cardDetails ->
       debugLog("Card recognized : $cardDetails", cardScannerOptions)
 
@@ -222,6 +223,7 @@ class CardScannerCameraActivity : AppCompatActivity() {
   }
 
   override fun onBackPressed() {
+    cardScanner?.cancelTimer()
     setResult(Activity.RESULT_CANCELED)
     super.onBackPressed()
   }

--- a/android/src/main/java/com/nateshmbhat/card_scanner/CardScannerCameraActivity.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/CardScannerCameraActivity.kt
@@ -11,6 +11,8 @@ import android.util.Log
 import android.view.View
 import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.view.animation.AccelerateDecelerateInterpolator
+import android.widget.ImageButton
+import android.widget.TextView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.camera.core.*
@@ -39,11 +41,15 @@ class CardScannerCameraActivity : AppCompatActivity() {
   private var textRecognizer: TextRecognizer? = null
   private var analysisUseCase: ImageAnalysis? = null
   private var cardScannerOptions: CardScannerOptions? = null
+  private var cardScanner: CardScanner? = null
+  private var camera: Camera? = null
+  private var isTorchOn: Boolean = false
   private lateinit var cameraExecutor: ExecutorService
   lateinit var animator: ObjectAnimator
   lateinit var scannerLayout: View
   lateinit var scannerBar: View
   lateinit var backButton: View
+  lateinit var flashButton: ImageButton
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -53,11 +59,23 @@ class CardScannerCameraActivity : AppCompatActivity() {
     scannerLayout = findViewById(R.id.scannerLayout)
     scannerBar = findViewById(R.id.scannerBar)
     backButton = findViewById(R.id.backButton)
+    flashButton = findViewById(R.id.flashButton)
     supportActionBar?.hide()
+
+    val promptText = findViewById<TextView>(R.id.promptText)
+    val prompt = cardScannerOptions?.prompt ?: ""
+    if (prompt.isEmpty()) {
+      promptText.visibility = View.GONE
+    } else {
+      promptText.text = prompt
+    }
 
     val vto = scannerLayout.viewTreeObserver
     backButton.setOnClickListener {
       finish()
+    }
+    flashButton.setOnClickListener {
+      toggleFlashlight()
     }
     vto.addOnGlobalLayoutListener(object : OnGlobalLayoutListener {
       override fun onGlobalLayout() {
@@ -133,7 +151,7 @@ class CardScannerCameraActivity : AppCompatActivity() {
     val previewView = findViewById<PreviewView>(R.id.cameraView)
 
     previewUseCase!!.setSurfaceProvider(previewView.surfaceProvider)
-    cameraProvider!!.bindToLifecycle( /* lifecycleOwner= */this, cameraSelector!!, previewUseCase)
+    camera = cameraProvider!!.bindToLifecycle( /* lifecycleOwner= */this, cameraSelector!!, previewUseCase)
   }
 
   private fun bindAnalysisUseCase() {
@@ -152,20 +170,31 @@ class CardScannerCameraActivity : AppCompatActivity() {
     textRecognizer = TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS)
 
     debugLog("card scanner options : $cardScannerOptions", cardScannerOptions)
+    cardScanner = CardScanner(cardScannerOptions, { cardDetails ->
+      debugLog("Card recognized : $cardDetails", cardScannerOptions)
+
+      val returnIntent: Intent = Intent()
+      returnIntent.putExtra(SCAN_RESULT, cardDetails)
+      setResult(Activity.RESULT_OK, returnIntent)
+      finish()
+    }, onCardScanFailed = {
+      onBackPressed()
+    })
     val analysisUseCase = ImageAnalysis.Builder().build()
             .also {
-              it.setAnalyzer(cameraExecutor, CardScanner(cardScannerOptions, { cardDetails ->
-                debugLog("Card recognized : $cardDetails", cardScannerOptions)
-
-                val returnIntent: Intent = Intent()
-                returnIntent.putExtra(SCAN_RESULT, cardDetails)
-                setResult(Activity.RESULT_OK, returnIntent)
-                finish()
-              }, onCardScanFailed = {
-                onBackPressed()
-              }))
+              it.setAnalyzer(cameraExecutor, cardScanner!!)
             }
     cameraProvider!!.bindToLifecycle( /* lifecycleOwner= */this, cameraSelector!!, analysisUseCase)
+  }
+
+  private fun toggleFlashlight() {
+    camera?.let {
+      if (it.cameraInfo.hasFlashUnit()) {
+        isTorchOn = !isTorchOn
+        it.cameraControl.enableTorch(isTorchOn)
+        flashButton.setImageResource(if (isTorchOn) R.drawable.ic_flash_on else R.drawable.ic_flash_off)
+      }
+    }
   }
 
   companion object {
@@ -188,6 +217,7 @@ class CardScannerCameraActivity : AppCompatActivity() {
 
   override fun onDestroy() {
     super.onDestroy()
+    cardScanner?.cancelTimer()
     textRecognizer?.close()
   }
 

--- a/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/CardScanner.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/CardScanner.kt
@@ -30,10 +30,12 @@ class CardScanner(private val scannerOptions: CardScannerOptions?, private val o
 
           override fun onFinish() {
             if (scanCompleted) return
+            scanCompleted = true
             debugLog("Card scanner timeout reached", scannerOptions);
             val cardDetails = cardDetailsScanOptimizer.getOptimalCardDetails()
             if (cardDetails != null) {
-              finishCardScanning(cardDetails)
+              debugLog("OPTIMAL Card details : $cardDetails", scannerOptions)
+              onCardScanned(cardDetails)
             } else {
               onCardScanFailed()
             }

--- a/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/CardScanner.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/CardScanner.kt
@@ -20,14 +20,16 @@ class CardScanner(private val scannerOptions: CardScannerOptions?, private val o
   val singleFrameCardScanner: SingleFrameCardScanner = SingleFrameCardScanner(scannerOptions!!)
   val cardDetailsScanOptimizer: CardDetailsScanOptimizer = CardDetailsScanOptimizer(scannerOptions!!)
   var scanCompleted: Boolean = false
+  private var timer: CountDownTimer? = null
 
   init {
     if (scannerOptions != null) {
       if (scannerOptions.cardScannerTimeOut > 0) {
-        val timer = object : CountDownTimer((scannerOptions.cardScannerTimeOut!! * 1000).toLong(), 1000) {
+        timer = object : CountDownTimer((scannerOptions.cardScannerTimeOut * 1000).toLong(), 1000) {
           override fun onTick(millisUntilFinished: Long) {}
 
           override fun onFinish() {
+            if (scanCompleted) return
             debugLog("Card scanner timeout reached", scannerOptions);
             val cardDetails = cardDetailsScanOptimizer.getOptimalCardDetails()
             if (cardDetails != null) {
@@ -38,7 +40,7 @@ class CardScanner(private val scannerOptions: CardScannerOptions?, private val o
             debugLog("Finishing card scan with card details : ${cardDetails}", scannerOptions);
           }
         }
-        timer.start()
+        timer?.start()
       }
     }
   }
@@ -88,8 +90,15 @@ class CardScanner(private val scannerOptions: CardScannerOptions?, private val o
   }
 
   private fun finishCardScanning(cardDetails: CardDetails) {
+    if (scanCompleted) return
     debugLog("OPTIMAL Card details : $cardDetails", scannerOptions)
     scanCompleted = true
+    timer?.cancel()
     onCardScanned(cardDetails)
+  }
+
+  fun cancelTimer() {
+    scanCompleted = true
+    timer?.cancel()
   }
 }

--- a/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/models/CardScannerOptions.kt
+++ b/android/src/main/java/com/nateshmbhat/card_scanner/scanner_core/models/CardScannerOptions.kt
@@ -16,7 +16,8 @@ data class CardScannerOptions(
     val enableLuhnCheck: Boolean,
     val cardScannerTimeOut: Int,
     val enableDebugLogs: Boolean,
-    val possibleCardHolderNamePositions: List<String>
+    val possibleCardHolderNamePositions: List<String>,
+    val prompt: String
 ) : Parcelable {
 
     constructor(parcel: Parcel) : this(
@@ -30,7 +31,8 @@ data class CardScannerOptions(
         enableLuhnCheck = parcel.readByte() != 0.toByte(),
         cardScannerTimeOut = parcel.readInt(),
         enableDebugLogs = parcel.readByte() != 0.toByte(),
-        possibleCardHolderNamePositions = parcel.createStringArrayList() ?: emptyList()
+        possibleCardHolderNamePositions = parcel.createStringArrayList() ?: emptyList(),
+        prompt = parcel.readString() ?: ""
     )
 
     constructor(configMap: Map<String, String>) : this(
@@ -45,7 +47,8 @@ data class CardScannerOptions(
         cardScannerTimeOut = configMap[ParcelKeys.cardScannerTimeOut.value]?.toInt() ?: 0,
         enableDebugLogs = configMap[ParcelKeys.enableDebugLogs.value]?.toBoolean() ?: false,
         possibleCardHolderNamePositions = configMap[ParcelKeys.possibleCardHolderNamePositions.value]?.split(',')
-            ?: listOf(CardHolderNameScanPositions.belowCardNumber.value)
+            ?: listOf(CardHolderNameScanPositions.belowCardNumber.value),
+        prompt = configMap[ParcelKeys.prompt.value] ?: ""
     )
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -60,6 +63,7 @@ data class CardScannerOptions(
         parcel.writeInt(cardScannerTimeOut)
         parcel.writeByte(if (enableDebugLogs) 1 else 0)
         parcel.writeStringList(possibleCardHolderNamePositions ?: emptyList())
+        parcel.writeString(prompt)
     }
 
     override fun describeContents(): Int {
@@ -79,7 +83,8 @@ data class CardScannerOptions(
             enableLuhnCheck("enableLuhnCheck"),
             cardScannerTimeOut("cardScannerTimeOut"),
             enableDebugLogs("enableDebugLogs"),
-            possibleCardHolderNamePositions("possibleCardHolderNamePositions")
+            possibleCardHolderNamePositions("possibleCardHolderNamePositions"),
+            prompt("prompt")
         }
 
         override fun createFromParcel(parcel: Parcel): CardScannerOptions {

--- a/android/src/main/res/drawable/ic_flash_off.xml
+++ b/android/src/main/res/drawable/ic_flash_off.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#F0F0F2"
+        android:pathData="M3.27 3L2 4.27l5 5V13h3v9l3.58-6.14L17.73 20 19 18.73 3.27 3zM17 10h-4l4-8H7v2.18l8.46 8.46L17 10z" />
+</vector>

--- a/android/src/main/res/drawable/ic_flash_on.xml
+++ b/android/src/main/res/drawable/ic_flash_on.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="20dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <path
+        android:fillColor="#F0F0F2"
+        android:pathData="M7 2v11h3v9l7-12h-4l4-8z" />
+</vector>

--- a/android/src/main/res/layout/card_scanner_camera_activity.xml
+++ b/android/src/main/res/layout/card_scanner_camera_activity.xml
@@ -28,6 +28,17 @@
                 android:layout_height="17dp"
                 android:textSize="24sp"/>
 
+            <ImageButton
+                android:id="@+id/flashButton"
+                android:layout_width="20dp"
+                android:layout_height="20dp"
+                android:layout_alignParentEnd="true"
+                android:layout_marginEnd="28dp"
+                android:layout_marginTop="28dp"
+                android:background="@android:color/transparent"
+                android:src="@drawable/ic_flash_off"
+                android:scaleType="fitCenter"
+                android:contentDescription="Toggle flashlight" />
 
         </RelativeLayout>
 
@@ -76,12 +87,12 @@
             android:background="@color/semitransparent" >
 
         <TextView
+            android:id="@+id/promptText"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="center"
             android:lineSpacingExtra="6sp"
             android:layout_centerInParent="true"
-            android:text="Scan your card to proceed"
             android:textAlignment="center"
             android:textColor="#f0f0f5"
             android:textSize="12sp" />

--- a/ios/Classes/Scanner Core/CameraViewController.swift
+++ b/ios/Classes/Scanner Core/CameraViewController.swift
@@ -170,6 +170,7 @@ class CameraViewController: UIViewController {
     
     
     func addScanYourCardToProceedLabel() {
+        guard !self.prompt.isEmpty else { return }
         DispatchQueue.main.async {
             let center = self.view.center
             let scanYourCardToProceedLabel = UILabel(

--- a/ios/Classes/Scanner Core/CameraViewController.swift
+++ b/ios/Classes/Scanner Core/CameraViewController.swift
@@ -20,7 +20,7 @@ protocol CameraDelegate {
 class CameraViewController: UIViewController {
     var scansDroppedSinceLastReset: Int = 0
     
-    let textRecognizer = TextRecognizer.textRecognizer()
+    let textRecognizer = TextRecognizer.textRecognizer(options: TextRecognizerOptions())
     
     var cameraDelegate: CameraDelegate?
     var captureSession: AVCaptureSession!

--- a/ios/Classes/Scanner Core/Models/CardScannerOptions.swift
+++ b/ios/Classes/Scanner Core/Models/CardScannerOptions.swift
@@ -20,7 +20,7 @@ public class CardScannerOptions {
     var cardScannerTimeOut: Int = 0
     var enableDebugLogs: Bool = false
     var possibleCardHolderNamePositions: [String] = [CardHolderNameScanPositions.belowCardNumber.rawValue]
-    var prompt: String = "Scan the back of your Credit Card to proceed"
+    var prompt: String = ""
     var cameraOrientation: CameraOrientation = .portrait
     
     init(

--- a/ios/Classes/SwiftCardScannerPlugin.swift
+++ b/ios/Classes/SwiftCardScannerPlugin.swift
@@ -9,23 +9,30 @@ public class SwiftCardScannerPlugin: NSObject, FlutterPlugin {
     }
     
     var result: FlutterResult?
-    
+    var scanTimer: Timer?
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         if (call.method == "scan_card") {
             let scanProcessor: ScanProcessor = ScanProcessor(withOptions: CardScannerOptions(from: call.arguments as? [String: String]))
-            
+
             scanProcessor.scanProcessorDelegate = self
             var secondsRemaining = CardScannerOptions(from: call.arguments as? [String: String]).cardScannerTimeOut
-            
+
+            self.result = result
+
             DispatchQueue.main.async {
                 scanProcessor.startScanning()
             }
-            
+
             if secondsRemaining != 0 {
-                Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { (Timer) in
+                scanTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
                     if secondsRemaining <= 0 {
-                        Timer.invalidate()
+                        timer.invalidate()
+                        self?.scanTimer = nil
                         DispatchQueue.main.async {
+                            guard let pendingResult = self?.result else { return }
+                            self?.result = nil
+                            pendingResult(nil)
                             UIApplication.shared.keyWindow?.rootViewController?.dismiss(
                                 animated: true,
                                 completion: nil
@@ -36,8 +43,6 @@ public class SwiftCardScannerPlugin: NSObject, FlutterPlugin {
                     }
                 }
             }
-            
-            self.result = result
         } else {
             result(FlutterMethodNotImplemented)
         }
@@ -46,7 +51,10 @@ public class SwiftCardScannerPlugin: NSObject, FlutterPlugin {
 
 extension SwiftCardScannerPlugin: ScanProcessorDelegate {
     public func scanProcessor(_ scanProcessor: ScanProcessor, didFinishScanning card: CardDetails) {
+        scanTimer?.invalidate()
+        scanTimer = nil
         if let result = self.result {
+            self.result = nil
             result(card.dictionary)
         }
     }

--- a/ios/card_scanner.podspec
+++ b/ios/card_scanner.podspec
@@ -17,8 +17,8 @@ A new Flutter plugin.
   s.source_files = 'Classes/**/*'
   s.resources = 'Assets/*.png'
   s.dependency 'Flutter'
-  s.dependency 'GoogleMLKit/TextRecognition', '~> 3.2.0'
-  s.platform = :ios, '12.0'
+  s.dependency 'GoogleMLKit/TextRecognition', '>= 6.0.0'
+  s.platform = :ios, '15.0'
   s.static_framework = true
 
   # Flutter.framework supports both x86_64 and arm64 simulators.

--- a/lib/card_scanner.dart
+++ b/lib/card_scanner.dart
@@ -17,7 +17,6 @@ class CardScanner {
     scanOptions ??= CardScanOptions();
     final scanResult = await _channel.invokeMapMethod<String, String>(
         _scan_card, scanOptions.map);
-    print("method channel : GOT VALUE FROM METHOD CHANNEL : $scanResult");
 
     if (scanResult != null) return CardDetails.fromMap(scanResult);
 

--- a/lib/models/card_scan_options.dart
+++ b/lib/models/card_scan_options.dart
@@ -40,6 +40,10 @@ class CardScanOptions {
   ///defaults to [CardHolderNameScanPosition.belowCardNumber]
   final List<CardHolderNameScanPosition> possibleCardHolderNamePositions;
 
+  /// Prompt text displayed on the scanner screen.
+  /// Defaults to empty string which hides the prompt label.
+  final String prompt;
+
   const CardScanOptions(
       {this.scanExpiryDate = true,
       this.scanCardHolderName = false,
@@ -51,7 +55,8 @@ class CardScanOptions {
       this.enableLuhnCheck = true,
       this.enableDebugLogs = false,
       this.cardScannerTimeOut = 0,
-      this.possibleCardHolderNamePositions = const [CardHolderNameScanPosition.belowCardNumber]});
+      this.possibleCardHolderNamePositions = const [CardHolderNameScanPosition.belowCardNumber],
+      this.prompt = ''});
 
   Map<String, String> get map {
     final List<String> possibleNamePositions = [];
@@ -71,7 +76,8 @@ class CardScanOptions {
       'enableLuhnCheck': enableLuhnCheck.toString(),
       'cardScannerTimeOut': cardScannerTimeOut.toString(),
       'enableDebugLogs': enableDebugLogs.toString(),
-      'possibleCardHolderNamePositions': possibleNamePositions.join(",")
+      'possibleCardHolderNamePositions': possibleNamePositions.join(","),
+      'prompt': prompt
     };
   }
 }


### PR DESCRIPTION
## Summary

- **Fix #58**: Fix app crash on back press when `cardScannerTimeOut` is set. Timer is now properly cancelled in all exit paths (back press, scan complete, destroy) on both Android and iOS.
- **Fix #86 / #47**: Make prompt text configurable via `CardScanOptions.prompt`. Defaults to empty (hidden). Replaces hardcoded strings on both platforms.
- **Fix #81 / #70**: Add flashlight toggle button on Android scanner UI, matching existing iOS functionality. Uses CameraX `enableTorch` with `hasFlashUnit()` guard.
- **Fix #88**: Upgrade outdated ML Kit and CameraX dependencies for compatibility with modern Flutter ML Kit packages.
- **Security**: Remove debug `print()` that logged sensitive card data to console.

## Changes

### Dart
- Added `prompt` field to `CardScanOptions` with `''` default
- Removed debug print of card scan results in `card_scanner.dart`

### Android
- Store `CardScanner` instance and cancel timer on activity destroy/back press
- Parse and display configurable prompt text (hidden when empty)
- Add flashlight toggle button with flash on/off vector drawables
- Upgrade `play-services-mlkit-text-recognition` 18.0.2 → 19.0.1
- Upgrade CameraX from 1.1.0-alpha to stable 1.3.4
- Upgrade appcompat 1.1.0 → 1.6.1, constraintlayout 1.1.3 → 2.1.4
- Replace deprecated `jcenter()` with `mavenCentral()`

### iOS
- Store and invalidate scan timer with `[weak self]` to prevent retain cycles
- Hide prompt label when prompt string is empty
- Widen `GoogleMLKit/TextRecognition` from `~> 3.2.0` to `>= 6.0.0` (resolves CocoaPods conflict with `google_mlkit_text_recognition ~> 9.0.0`)
- Bump iOS minimum deployment target from 12.0 to 15.0 (required by ML Kit 7+)
- Update `TextRecognizer` factory to use `options:` parameter (required by ML Kit 4+)

## Test plan

- [ ] Verify scanner opens and scans cards on Android and iOS
- [ ] Press back during timeout — confirm no crash on either platform
- [ ] Pass custom `prompt` string — verify it appears on scanner screen
- [ ] Pass empty `prompt` — verify no text label is shown
- [ ] Tap flashlight button on Android — verify torch toggles on/off
- [ ] Use alongside `google_mlkit_text_recognition` package — verify no CocoaPods version conflict
- [ ] Verify Android builds with no dependency resolution errors

Closes #58, #47, #70, #81, #86, #88

https://claude.ai/code/session_01JAifbQeQhMFYSG4w1cuLvx